### PR TITLE
Manipulação da permissão de acesso a camera feito

### DIFF
--- a/src/app/components/card-selfie-tela2/card-selfie-tela2.component.ts
+++ b/src/app/components/card-selfie-tela2/card-selfie-tela2.component.ts
@@ -75,9 +75,7 @@ export class CardSelfieTela2Component implements OnInit {
     alert('Foto feita!')
     let selfieBase64 = await this.sendingPhoto()
     this.uploadSelfie.testSendImageService(selfieBase64)
-    
     this.stream = this.cameraPermission.getStream()
-    console.log(this.stream)
     this.cameraPermission.turnOffCamera(this.stream)
   }
 

--- a/src/app/components/card-selfie/card-selfie.component.html
+++ b/src/app/components/card-selfie/card-selfie.component.html
@@ -8,8 +8,8 @@
             <div *ngIf="foto != ''" class="placehold-foto">
                 <img [src]="foto" [height]="250" [width]="250">
             </div>
-            <button *ngIf="statusCard === 'NEED_TO_SEND' || statusCard === undefined || statusCard === 'DECLINED'" class="botao-tirar-foto" [ngStyle]="{'margin-top':marginTop, 'margin-bottom':marginBottom }" (click)="checkPermissions()">TIRAR</button>  
-            <button *ngIf="statusCard === 'APPROVED' || statusCard === 'PENDING_REVIEW'" disabled='true' class="botao-tirar-foto" [ngStyle]="{'margin-top':marginTop, 'margin-bottom':marginBottom, 'background-color':'grey'}" (click)="termos()">TIRAR</button> 
+            <button *ngIf="statusCard === 'NEED_TO_SEND' || statusCard === undefined || statusCard === 'DECLINED'" class="botao-tirar-foto" [ngStyle]="{'margin-top':marginTop, 'margin-bottom':marginBottom }" (click)="turnOnCamera()">TIRAR</button>  
+            <button *ngIf="statusCard === 'APPROVED' || statusCard === 'PENDING_REVIEW'" disabled='true' class="botao-tirar-foto" [ngStyle]="{'margin-top':marginTop, 'margin-bottom':marginBottom, 'background-color':'grey'}">TIRAR</button> 
         </ul>
     </div>
 </section>

--- a/src/app/components/card-selfie/card-selfie.component.ts
+++ b/src/app/components/card-selfie/card-selfie.component.ts
@@ -28,18 +28,12 @@ export class CardSelfieComponent implements OnInit {
 
   constructor(private dialog : MatDialog, private cameraPermissions : CameraPermissions, private cardStatusService : CardStatusService) { }
 
+
   dialogRef !: any
   dialogRef2 !: any
 
   ngOnInit(): void {
     this.getStatus()
-    this.turnOnCamera()
-  }
-  
-  turnOnCamera(){
-    if(this.statusCard === "NEED_TO_SEND" || this.statusCard === "DECLINED" || this.statusCard === undefined){
-      this.cameraPermissions.turnOnCamera() 
-    }
   }
 
   checkPermissions(){
@@ -47,7 +41,7 @@ export class CardSelfieComponent implements OnInit {
     navigator.permissions.query({ name : permissionName }).then(result => {
       let action = result.state
       if(action === "granted"){
-        this.termos()
+        this.turnOnCamera()
       }
       if(action === "denied"){
         this.ativarNovamente()
@@ -55,13 +49,12 @@ export class CardSelfieComponent implements OnInit {
     })
   }
   
-  termos(){
-    if(this.statusCard === 'APPROVED' || this.statusCard === 'PENDING_REVIEW'){
-      alert('Voce ja tirou foto!')
+  turnOnCamera(){
+    this.cameraPermissions.turnOnCamera()
+    this.dialogRef = this.dialog.open(PopupComponent) 
+    if(this.dialogRef.nextPage === true){
+      this.dialogRef.popup
     }
-      this.dialogRef = this.dialog.open(PopupComponent) 
-      if(this.dialogRef.nextPage === true)
-        this.dialogRef.popup
   
   }
 

--- a/src/app/components/card-selfie/card-selfie.component.ts
+++ b/src/app/components/card-selfie/card-selfie.component.ts
@@ -28,7 +28,6 @@ export class CardSelfieComponent implements OnInit {
 
   constructor(private dialog : MatDialog, private cameraPermissions : CameraPermissions, private cardStatusService : CardStatusService) { }
 
-  //statusCard!:any
   dialogRef !: any
   dialogRef2 !: any
 
@@ -38,7 +37,9 @@ export class CardSelfieComponent implements OnInit {
   }
   
   turnOnCamera(){
-    this.cameraPermissions.turnOnCamera() 
+    if(this.statusCard === "NEED_TO_SEND" || this.statusCard === "DECLINED" || this.statusCard === undefined){
+      this.cameraPermissions.turnOnCamera() 
+    }
   }
 
   checkPermissions(){


### PR DESCRIPTION
Feitas as alterações requeridas.
Ao clicar no botão tirar foto, o navegador dispara um popup pedindo permissão. Ao final do fluxo, quando há a confirmação da foto, desliga a câmera.